### PR TITLE
Team actions added

### DIFF
--- a/server/app/controllers/api/events_controller.rb
+++ b/server/app/controllers/api/events_controller.rb
@@ -13,25 +13,25 @@ class Api::EventsController < ApplicationController
     end
   end
 
-  # def show
-  #   @event = get_event
-  #   render json: @event, status: 200
-  # end
-  #
-  # def update
-  #   @event = get_event
-  #   if @event.update_attributes(event_params)
-  #     render json: @event, status: 201
-  #   else
-  #     render json: @event.errors, status: 422
-  #   end
-  # end
-  #
-  # def destroy
-  #   @event = get_event
-  #   @event.destroy
-  #   render json: { head: :no_content }
-  # end
+  def show
+    @event = get_event
+    render json: @event, status: 200
+  end
+
+  def update
+    @event = get_event
+    if @event.update_attributes(event_params)
+      render json: @event, status: 201
+    else
+      render json: @event.errors, status: 422
+    end
+  end
+
+  def destroy
+    @event = get_event
+    @event.destroy
+    render json: { head: :no_content }
+  end
 
   private
 
@@ -40,6 +40,6 @@ class Api::EventsController < ApplicationController
   end
 
   def event_params
-    params.require(:event).permit(:name, :location, :occurs_on, :starts_at)
+    params.require(:event).permit(:name, :league_id, :location, :occurs_on, :starts_at)
   end
 end

--- a/server/app/controllers/api/teams_controller.rb
+++ b/server/app/controllers/api/teams_controller.rb
@@ -1,4 +1,51 @@
 class Api::TeamsController < ApplicationController
-  def index
+  # def index
+  #   @teams = Team.all
+  # end
+
+  def create
+    @league = get_league
+    @team = @league.teams.new(team_params)
+    if @team.save
+      render json: @team, status: 201
+    else
+      render json: @team.errors, status: 422
+    end
+  end
+
+  def show
+    @league = get_league
+    @team = get_team(@league)
+    render json: @team, status: 200
+  end
+
+  def update
+    @league = get_league
+    @team = get_team(@league)
+    if @team.update_attributes(team_params)
+      render json: @team, status: 201
+    else
+      render json: @team.errors, status: 422
+    end
+  end
+
+  def destroy
+    @league = get_league
+    @team = get_team(@league)
+    @team.destroy
+    render json: { head: :no_content }
+  end
+
+  private
+  def get_league
+    League.find(params[:league_id])
+  end
+
+  def get_team(league)
+    league.teams.find(params[:id])
+  end
+
+  def team_params
+    params.require(:team).permit(:name, :logo, :ranking, :location)
   end
 end

--- a/server/app/controllers/api/teams_controller.rb
+++ b/server/app/controllers/api/teams_controller.rb
@@ -27,6 +27,14 @@ class Api::TeamsController < ApplicationController
     else
       render json: @team.errors, status: 422
     end
+    if params[:event_ids].present?
+      @team.events = event_ids
+      if @team.save
+        render json: @team, status: 201
+      else
+        render json: @team.errors, status: 422
+      end
+    end
   end
 
   def destroy
@@ -48,4 +56,9 @@ class Api::TeamsController < ApplicationController
   def team_params
     params.require(:team).permit(:name, :logo, :ranking, :location)
   end
+
+  def event_ids
+    Events.where(id: params[:event_ids])
+  end
+
 end

--- a/server/app/models/result.rb
+++ b/server/app/models/result.rb
@@ -3,4 +3,5 @@ class Result < ActiveRecord::Base
   belongs_to :team
 
   validates :event_id, :team_id, presence: true
+  validates :team_id, uniqueness: { scope: :event }
 end

--- a/server/test/controllers/api/events_controller_test.rb
+++ b/server/test/controllers/api/events_controller_test.rb
@@ -53,7 +53,6 @@ class Api::EventsControllerTest < ActionController::TestCase
 
   test 'updates with valid attributes' do
     patch :update, format: :json, id: @event, event: { name: 'Oh Hai' }
-
   end
 
   test 'does not update with invalid attributes' do
@@ -67,6 +66,5 @@ class Api::EventsControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
-
 
 end

--- a/server/test/controllers/api/events_controller_test.rb
+++ b/server/test/controllers/api/events_controller_test.rb
@@ -19,49 +19,54 @@ class Api::EventsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  # test 'creates with valid attribute' do
-  #   assert_difference('Event.count', 1) do
-  #     post :create, format: :json, event: { name: 'Events are cool',
-  #                   league_id: @league.id,
-  #                   location: 'Ici',
-  #                   occurs_on: 2015-07-31,
-  #                   starts_at: '15:31:12' }
-  #   end
-  #   assert_response :success
-  # end
+  test 'creates with valid attribute' do
+    assert_difference('Event.count', 1) do
+      post :create, format: :json, event: { name: 'Events are cool',
+                    league_id: @league.id,
+                    location: 'Ici',
+                    occurs_on: '2015-07-31',
+                    starts_at: '15:31:12' }
+    end
+    assert_response :success
+  end
 
-  # test 'does not create with invalid attribute' do
-  #   assert_no_difference('Event.count') do
-  #     post :create, format: :json, event: { name: '' }
-  #   end
-  #   assert_response 422
-  # end
-  #
-  # test 'GET #show' do
-  #   get :show, format: :json, id: @event
-  #   returned = JSON.parse(response.body, symbolize_names: true)
-  #   @attributes.each do |attr|
-  #     assert_equal @event.send(attr), returned[attr.to_sym]
-  #   end
-  #   assert_response :success
-  # end
-  #
-  # test 'updates with valid attributes' do
-  #   patch :update, format: :json, id: @event, event: { name: 'Oh Hai' }
-  #
-  # end
-  #
-  # test 'does not update with invalid attributes' do
-  #   patch :update, format: :json, id: @event, event: { name: '' }
-  #   assert_response 422
-  # end
-  #
-  # test 'DELETE #destroy' do
-  #   assert_difference('Event.count', -1) do
-  #     post :destroy, format: :json, id: @event
-  #   end
-  #   assert_response :success
-  # end
+  test 'does not create with invalid attribute' do
+    assert_no_difference('Event.count') do
+      post :create, format: :json, event: { name: '',
+                    league_id: @league.id,
+                    location: 'Ici',
+                    occurs_on: '2015-07-31',
+                    starts_at: '15:31:12' }
+    end
+    assert_response 422
+  end
+
+  test 'GET #show' do
+    get :show, format: :json, id: @event
+    returned = JSON.parse(response.body, symbolize_names: true)
+    @attributes.each do |attr|
+      @event.send(attr).class == Date ? expected = @event.send(attr).to_s : expected = @event.send(attr)
+      assert_equal expected, returned[attr.to_sym]
+    end
+    assert_response :success
+  end
+
+  test 'updates with valid attributes' do
+    patch :update, format: :json, id: @event, event: { name: 'Oh Hai' }
+
+  end
+
+  test 'does not update with invalid attributes' do
+    patch :update, format: :json, id: @event, event: { name: '' }
+    assert_response 422
+  end
+
+  test 'DELETE #destroy' do
+    assert_difference('Event.count', -1) do
+      post :destroy, format: :json, id: @event
+    end
+    assert_response :success
+  end
 
 
 end

--- a/server/test/controllers/api/teams_controller_test.rb
+++ b/server/test/controllers/api/teams_controller_test.rb
@@ -9,17 +9,6 @@ class Api::TeamsControllerTest < ActionController::TestCase
     @attributes = Team.attribute_names
   end
 
-  # test "GET #index" do
-  #   get :index, format: :json
-  #
-  #   returned = JSON.parse(response.body, symbolize_names: true)[0]
-  #   @attributes.each do |attr|
-  #     @team.send(attr).class == Date ? expected = @team.send(attr).to_s : expected = @team.send(attr)
-  #     assert_equal expected, returned[attr.to_sym]
-  #   end
-  #   assert_response :success
-  # end
-
   test 'creates with valid attribute' do
     assert_difference('Team.count', 1) do
       post :create, format: :json, league_id: @league, team: { name: 'TeamBoBerry' }

--- a/server/test/controllers/api/teams_controller_test.rb
+++ b/server/test/controllers/api/teams_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class Api::TeamsControllerTest < ActionController::TestCase
   def setup
     @league = leagues(:one)
+    @event = events(:one)
     @teams = Team.all
     @team = @league.teams.create!(name: 'Teamie McTeam')
     @attributes = Team.attribute_names
@@ -61,6 +62,20 @@ class Api::TeamsControllerTest < ActionController::TestCase
       post :destroy, league_id: @league, format: :json, id: @team
     end
     assert_response :success
+  end
+
+  test 'can join an event (has result with no score)' do
+    assert_difference('Result.count', 1) do
+      @team.events << @event
+    end
+    assert @team.events.include?(@event)
+  end
+
+  test 'cannot join the same event twice' do
+    @team.events << @event
+    assert_raises(ActiveRecord::RecordInvalid) do
+      @team.events << @event
+    end
   end
 
 end

--- a/server/test/controllers/api/teams_controller_test.rb
+++ b/server/test/controllers/api/teams_controller_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class Api::TeamsControllerTest < ActionController::TestCase
+  def setup
+    @league = leagues(:one)
+    @teams = Team.all
+    @team = @league.teams.create!(name: 'Teamie McTeam')
+    @attributes = Team.attribute_names
+  end
+
+  # test "GET #index" do
+  #   get :index, format: :json
+  #
+  #   returned = JSON.parse(response.body, symbolize_names: true)[0]
+  #   @attributes.each do |attr|
+  #     @team.send(attr).class == Date ? expected = @team.send(attr).to_s : expected = @team.send(attr)
+  #     assert_equal expected, returned[attr.to_sym]
+  #   end
+  #   assert_response :success
+  # end
+
+  test 'creates with valid attribute' do
+    assert_difference('Team.count', 1) do
+      post :create, format: :json, league_id: @league, team: { name: 'TeamBoBerry' }
+    end
+    assert_response :success
+  end
+
+  test 'does not create with invalid attribute' do
+    assert_no_difference('Team.count') do
+      post :create, format: :json, league_id: @league, team: { name: '' }
+    end
+    assert_response 422
+  end
+
+  test 'GET #show' do
+    get :show, format: :json, league_id: @league, id: @team
+    returned = JSON.parse(response.body, symbolize_names: true)
+    @attributes.each do |attr|
+      if @team.send(attr).class == ActiveSupport::TimeWithZone
+        assert_equal @team.send(attr).to_s, returned[attr.to_sym].to_time.utc.to_s
+      else
+        assert_equal expected = @team.send(attr), returned[attr.to_sym]
+      end
+    end
+    assert_response :success
+  end
+
+  test 'updates with valid attributes' do
+    patch :update, format: :json, league_id: @league, id: @team, team: { name: 'Oh Hai' }
+
+  end
+
+  test 'does not update with invalid attributes' do
+    patch :update, format: :json, league_id: @league, id: @team, team: { name: '' }
+    assert_response 422
+  end
+
+  test 'DELETE #destroy' do
+    assert_difference('Team.count', -1) do
+      post :destroy, league_id: @league, format: :json, id: @team
+    end
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
basic team actions added and tested (create, show, update, destroy; index not included, given the nesting of teams under league)
added and tested ability for a team to join an event. restriction included to prevent a team from joining the same event multiple times.
